### PR TITLE
fix(installer): discard residual input before name prompt and offer h…

### DIFF
--- a/.wize/knowledge/decisions/ADR-002-installer-prompt-and-harness.md
+++ b/.wize/knowledge/decisions/ADR-002-installer-prompt-and-harness.md
@@ -1,0 +1,30 @@
+---
+status: accepted
+date: 2026-06-13
+deciders: André Dantas, Claude
+---
+
+# ADR-002: Fix installer prompt residual-line bug and offer to open a harness
+
+## Context
+
+During installation in an interactive terminal, the prompt for "How should the agents call you?" skipped user input and immediately accepted the default. The next prompt (gitignore) was then printed on the same line. This happened because the custom `prompt()` helper in `wize-dev-kit install` consumed a residual empty line left in the readline queue by the preceding `prompts`-library questions.
+
+Additionally, after installation the CLI only told the user to "restart your IDE" without offering to launch a detected harness directly, even when `claude`, `codex`, or `opencode` was available on PATH.
+
+## Decision
+
+1. **Fix `prompt()`** in `tools/installer/wize-cli.js` so it discards the `_queue` of stale lines before writing the question and waiting for fresh input.
+2. **Offer to open a harness** at the end of interactive installs. When a harness is detected on PATH, ask the user whether to launch it with `/wize-orchestrator`. If declined, show the equivalent manual command. If no harness is detected, keep the existing instruction to open the IDE manually.
+
+## Alternatives considered
+
+- **Keep `prompt()` as-is and add a flush hack around each call.** Rejected — the queue can contain stale input at multiple points; fixing it centrally is more robust.
+- **Launch the harness automatically without asking.** Rejected — unexpected terminal behavior and IDE context switches should be opt-in.
+- **Use `prompts` for the name question too.** Rejected — we intentionally use a plain text prompt for simple string input; the fix preserves that while clearing residual state.
+
+## Consequences
+
+- The name prompt now correctly waits for user input in interactive mode.
+- Users can jump straight into Wizer from the installer when a harness is present.
+- CI / non-TTY paths are unaffected because the new offer is gated on `INTERACTIVE`.

--- a/tools/installer/wize-cli.js
+++ b/tools/installer/wize-cli.js
@@ -21,6 +21,7 @@ const { cmdSync: cmdSyncReal } = require('./commands/sync.js');
 const { cmdAgentList, cmdAgentCreate, cmdAgentEdit } = require('./commands/agent.js');
 const { cmdDoctor } = require('./commands/doctor.js');
 const { cmdDocumentProject } = require('./commands/document-project.js');
+const { detectHarnessCli, manualInstructions } = require('./baseline.js');
 
 const INTERACTIVE = process.stdout.isTTY && process.stdin.isTTY;
 
@@ -127,7 +128,9 @@ function getRl() {
 function prompt(question) {
   process.stdout.write(question);
   getRl();
-  if (_queue.length) return Promise.resolve(_queue.shift().trim());
+  // Discard any residual lines left by previous prompts (e.g. prompts library)
+  // so that this prompt always waits for fresh user input.
+  _queue = [];
   return new Promise(resolve => _waiters.push((line) => resolve(line.trim())));
 }
 
@@ -458,6 +461,32 @@ async function cmdInstall(args) {
       } else {
         console.log('\nSkipped documentation. Run `wize-dev-kit document-project` later.');
       }
+    }
+  }
+
+  // Offer to open a detected AI harness interactively.
+  if (INTERACTIVE) {
+    const ideTargetCodes = targets.map(t => t.code);
+    const harnesses = detectHarnessCli({ preferIde: ideTargetCodes });
+    if (harnesses.length) {
+      const primary = harnesses[0];
+      const { cmd, args } = primary.buildCmd('/wize-orchestrator');
+      const shown = `${cmd} ${args.map(a => /\s/.test(a) ? '"' + a + '"' : a).join(' ')}`;
+      const openHarness = await confirm(
+        `\nA harness was detected: ${primary.code} (${primary.path}).\n` +
+        `Open it now with Wizer? (runs: ${shown})`,
+        true
+      );
+      if (openHarness) {
+        const { spawnSync } = require('node:child_process');
+        console.log(`\nLaunching ${shown}...`);
+        spawnSync(cmd, args, { cwd, stdio: 'inherit' });
+      } else {
+        console.log(manualInstructions(primary).replace('/wize-document-project', '/wize-orchestrator'));
+      }
+    } else {
+      console.log('\nNo AI harness CLI detected on PATH (claude / codex / opencode).');
+      console.log('Open your IDE in this repo and run: /wize-orchestrator');
     }
   }
 


### PR DESCRIPTION
…arness launch

- prompt() now clears the readline queue before waiting for fresh input, preventing the 'How should the agents call you?' question from being skipped and falling back to the system username.
- At the end of interactive installs, detect available harnesses on PATH and offer to launch /wize-orchestrator directly; otherwise show the equivalent manual command.