### PR TITLE
fix: align codex installer output path

### DIFF
--- a/.wize/config/project.toml
+++ b/.wize/config/project.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "wize-dev-kit"
-kit_version = "0.7.1"
+kit_version = "0.7.2"
 
 [install]
 profiles = ["core"]

--- a/.wize/implementation/investigations/2026-06-27-codex-installer-skill-path.md
+++ b/.wize/implementation/investigations/2026-06-27-codex-installer-skill-path.md
@@ -1,0 +1,30 @@
+---
+date: 2026-06-27
+author: Shuri
+severity: high
+status: concluded
+---
+
+# Investigation — codex-installer-skill-path
+
+## Frame
+Codex install no projeto de exemplo estava gerando artefatos, mas o harness não carregava as skills Wize. O problema foi notado após comparar o comportamento com Claude Code, onde as skills apareciam normalmente. Impacto alto: a promessa multi-harness do instalador falha no target `codex`.
+
+## Reproduce
+1. Criar um repo temporário.
+2. Rodar `node tools/installer/wize-cli.js install` escolhendo `codex` + `generic`.
+3. Inspecionar os arquivos gerados.
+**Expected:** skills em `.codex/skills/` para o Codex carregar no startup.
+**Actual:** skills em `.agents/skills/`, diretório que o Codex não usa neste harness.
+
+## Hypotheses
+1. **Path do adapter Codex está errado** — Confidence: high. Test: inspecionar `adapters/codex/render.js` e `adapter.yaml`. Result: confirmed.
+2. **Doctor/smoke/testes estão validados contra o path errado** — Confidence: high. Test: buscar `.agents/skills` em `test/` e `tools/installer/commands/doctor.js`. Result: confirmed.
+3. **Falha é no conteúdo das skills, não no path** — Confidence: low. Test: comparar estrutura gerada com Claude/Antigravity. Result: refuted.
+
+## Conclude
+- **Root cause:** o target `codex` foi implementado e testado contra `.agents/skills/`, enquanto o harness Codex usado pelo projeto carrega skills de `.codex/skills/`.
+- **Fix path:** alinhar o adapter Codex, o doctor, o bloco de `.gitignore`, os smoke tests e a documentação para `.codex/skills/`; depois validar com um install real.
+- **Effort:** S
+- **Risk of fix:** low
+- **Next:** /wize-quick-dev

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Format inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.7.2] — 2026-06-27
+
+### Fixed
+
+- **Codex adapter path corrigido.** O instalador e o `sync` agora renderizam as skills do target `codex` em `.codex/skills/`, alinhado com o harness usado no projeto. Antes, o kit escrevia em `.agents/skills/`, o que deixava o install aparentemente bem-sucedido, mas sem as skills serem carregadas no Codex.
+- **Diagnóstico e smoke alinhados ao Codex real.** `doctor`, `.gitignore`, smoke tests e testes de adapters passaram a validar `.codex/skills/`, evitando falso positivo no suporte multi-harness.
+
 ## [0.7.1] — 2026-06-21
 
 ### Changed

--- a/adapters/README.md
+++ b/adapters/README.md
@@ -9,7 +9,7 @@ Each adapter renders the kit's agents/skills/workflows into the file layout that
 | `claude-code` | `.claude/skills/wize-*/` | `SKILL.md` per agent/workflow | Default. Uses Claude Code skill folder pattern. |
 | `cursor` | `.cursor/rules/wize-*.mdc` | MDC | Each agent/skill becomes a rule file. |
 | `windsurf` | `.windsurf/agents/wize-*.md` | Markdown | Cascade-friendly. |
-| `codex` | `.codex/wize-*.md` | Markdown | OpenAI Codex CLI. |
+| `codex` | `.codex/skills/wize-*/` | `SKILL.md` per agent/workflow | OpenAI Codex. |
 | `continue` | `.continue/agents/wize-*.md` | Markdown | Continue agent slot. |
 | `kimi-code` | `.kimi/agents/wize-*.md` | Markdown | Moonshot Kimi Code. |
 | `opencode` | `.opencode/agents/wize-*.md` | Markdown | OpenCode CLI. |
@@ -23,4 +23,4 @@ Every adapter is a folder under `adapters/{code}/` with:
 - `render.js` — function `(kitRoot, projectRoot, opts) => void` that emits files.
 - `README.md` — adapter-specific notes.
 
-In v0.1 only the descriptors and READMEs are present; `render.js` is a stub printing what it would emit. Wiring is on the v0.2 roadmap.
+The shipped adapters emit real files through `render.js`.

--- a/adapters/codex/README.md
+++ b/adapters/codex/README.md
@@ -1,9 +1,9 @@
 # Adapter — codex
 
-OpenAI Codex CLI agents.
+OpenAI Codex skills.
 
-- **Target path:** `.codex/`
-- **File pattern:** `wize-*.md`
-- **Format:** markdown
+- **Target path:** `.codex/skills/`
+- **File pattern:** `wize-*/SKILL.md`
+- **Format:** Anthropic-compatible `SKILL.md`
 
-This v0.1 adapter ships the descriptor only. Actual rendering of `wize-*` agents/skills/workflows into the target IDE format is on the v0.2 roadmap.
+Renders the Wize skills directly into the folder Codex loads at startup.

--- a/adapters/codex/adapter.yaml
+++ b/adapters/codex/adapter.yaml
@@ -1,6 +1,6 @@
 code: codex
-description: "OpenAI Codex CLI agent skills (.agents/skills/, Anthropic-compatible)."
-target_path: ".agents/skills/"
+description: "OpenAI Codex agent skills (.codex/skills/, Anthropic-compatible)."
+target_path: ".codex/skills/"
 file_pattern: "wize-*/SKILL.md"
 file_format: markdown
 hooks:

--- a/adapters/codex/render.js
+++ b/adapters/codex/render.js
@@ -1,4 +1,4 @@
-// OpenAI Codex CLI adapter — emits .agents/skills/wize-{code}/SKILL.md per asset.
+// OpenAI Codex adapter — emits .codex/skills/wize-{code}/SKILL.md per asset.
 // Codex shares the Anthropic SKILL.md format and also reads the root AGENTS.md.
 
 'use strict';
@@ -7,7 +7,7 @@ const path = require('node:path');
 const { renderAnthropicSkills } = require('../../tools/installer/render-shared.js');
 
 function render(kitRoot, projectRoot, opts = {}) {
-  const targetDir = path.join(projectRoot, '.agents', 'skills');
+  const targetDir = path.join(projectRoot, '.codex', 'skills');
   return renderAnthropicSkills(kitRoot, targetDir, opts);
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wize-dev-kit",
-  "version": "0.4.1",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wize-dev-kit",
-      "version": "0.4.1",
+      "version": "0.7.2",
       "license": "MIT",
       "dependencies": {
         "prompts": "^2.4.2"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "wize-dev-kit",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Full-lifecycle AI-assisted development kit with Test Architect and Whiteport Design Studio embedded. Inspired by BMAD Method and WDS.",
   "keywords": [
     "ai",

--- a/test/adapters-all.test.js
+++ b/test/adapters-all.test.js
@@ -14,7 +14,7 @@ const KIT = path.resolve(__dirname, '..');
 const ADAPTERS = [
   { code: 'claude-code',  expectFile: (root) => path.join(root, '.claude/skills/wize-orchestrator/SKILL.md') },
   { code: 'antigravity',  expectFile: (root) => path.join(root, '.agent/skills/wize-orchestrator/SKILL.md') },
-  { code: 'codex',        expectFile: (root) => path.join(root, '.agents/skills/wize-orchestrator/SKILL.md') },
+  { code: 'codex',        expectFile: (root) => path.join(root, '.codex/skills/wize-orchestrator/SKILL.md') },
   { code: 'kimi-code',    expectFile: (root) => path.join(root, '.kimi/skills/wize-orchestrator/SKILL.md') },
   { code: 'cursor',       expectFile: (root) => path.join(root, '.cursor/rules/wize-orchestrator.mdc') },
   { code: 'windsurf',     expectFile: (root) => path.join(root, '.windsurf/rules/wize-orchestrator.md') },
@@ -56,7 +56,7 @@ test('generic adapter emits a root AGENTS.md', () => {
 const ANTHROPIC = [
   { code: 'claude-code',  base: '.claude' },
   { code: 'antigravity',  base: '.agent' },
-  { code: 'codex',        base: '.agents' },
+  { code: 'codex',        base: '.codex' },
   { code: 'kimi-code',    base: '.kimi' }
 ];
 

--- a/test/doctor.test.js
+++ b/test/doctor.test.js
@@ -148,7 +148,7 @@ test('adapterTargetPath returns expected paths for all known targets', () => {
   const paths = {
     'claude-code': '.claude/skills',
     'antigravity': '.agent/skills',
-    'codex':       '.agents/skills',
+    'codex':       '.codex/skills',
     'kimi-code':   '.kimi/skills',
     'cursor':      '.cursor/rules',
     'windsurf':    '.windsurf/rules',

--- a/test/smoke-install-security-overlay.test.js
+++ b/test/smoke-install-security-overlay.test.js
@@ -13,7 +13,7 @@ const KIT = path.resolve(__dirname, '..');
 // adapter.yaml convention), so we look up the right one for each.
 const TARGETS = [
   { code: 'claude-code', base: '.claude/skills' },
-  { code: 'codex',       base: '.agents/skills' },
+  { code: 'codex',       base: '.codex/skills' },
   { code: 'cursor',      base: '.cursor/rules' }
 ];
 

--- a/tools/installer/commands/doctor.js
+++ b/tools/installer/commands/doctor.js
@@ -58,7 +58,7 @@ function adapterTargetPath(targetCode, projectRoot) {
   switch (targetCode) {
     case 'claude-code':  return path.join(projectRoot, '.claude/skills');
     case 'antigravity':  return path.join(projectRoot, '.agent/skills');
-    case 'codex':        return path.join(projectRoot, '.agents/skills');
+    case 'codex':        return path.join(projectRoot, '.codex/skills');
     case 'kimi-code':    return path.join(projectRoot, '.kimi/skills');
     case 'cursor':       return path.join(projectRoot, '.cursor/rules');
     case 'windsurf':     return path.join(projectRoot, '.windsurf/rules');

--- a/tools/installer/setup-helpers.js
+++ b/tools/installer/setup-helpers.js
@@ -22,7 +22,7 @@ const GITIGNORE_BODY = [
   '# Generated IDE adapter outputs (regenerate with `npx wize-dev-kit install`)',
   '.claude/skills/wize-*',
   '.agent/skills/wize-*',
-  '.agents/skills/wize-*',
+  '.codex/skills/wize-*',
   '.kimi/skills/wize-*',
   '.cursor/rules/wize-*.mdc',
   '.windsurf/rules/wize-*.md',


### PR DESCRIPTION
## Summary
- render Codex skills into \.codex/skills instead of \.agents/skills
- align doctor, gitignore and tests with the real Codex harness path
- bump release to v0.7.2 and document the fix in the changelog

## Validation
- npm test
- npm run validate
- node --test test/adapters-all.test.js test/doctor.test.js test/smoke-install-security-overlay.test.js